### PR TITLE
Fix the get upload options exhaustive memory usage

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -92,11 +92,11 @@ class helper {
      *
      * @return array
      */
-    public static function get_upload_options($submissioncount = 0) {
+    public static function get_upload_options(int $submissioncount = 0) {
         $maxuploads = [];
         $maxuploads[ASSIGNSUBMISSION_EXTERNAL_SERVER_NOUPLOADS] = get_string('nouploads', 'assignsubmission_external_server');
         $maxuploads[ASSIGNSUBMISSION_EXTERNAL_SERVER_UNLIMITED] = get_string('unlimited', 'assignsubmission_external_server');
-        for ($i = 100; $i >= $submissioncount; $i--) {
+        for ($i = $submissioncount; $i <= 100; $i++) {
             $maxuploads[$i] = $i;
         }
         return $maxuploads;

--- a/locallib.php
+++ b/locallib.php
@@ -636,7 +636,7 @@ class assign_submission_external_server extends assign_submission_plugin {
      *
      * @return int The max number of upload attempts for a submissions.
      */
-    public function get_max_submissions() {
+    public function get_max_submissions() : int {
         global $DB;
 
         if (!$this->assignment->get_context()) {
@@ -644,7 +644,7 @@ class assign_submission_external_server extends assign_submission_plugin {
         } else {
             return $DB->get_field('assignsubmission_external_server', 'MAX(uploads)', [
                 'assignment' => $this->assignment->get_instance()->id,
-            ]);
+            ]) ?: 0;
         }
     }
 


### PR DESCRIPTION
If the $submissioncount parameter was null, this caused an endless loop until the memory limit is reached. The function was updated to prevent this behavior.

```
Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to
allocate 167772160 bytes) in
/var/www/html/mod/assign/submission/external_server/classes/helper.php
on line 100
```